### PR TITLE
feat: Adding the ability to rename the schema ColumnRef

### DIFF
--- a/quicksight_bulk_update_datasets.py
+++ b/quicksight_bulk_update_datasets.py
@@ -149,6 +149,11 @@ def rename_schema(
                 node_dict["schemaname"] is not None or node_dict["relname"] not in ctenames
             ) and (node.schemaname or "public") == source:
                 node.schemaname = target
+            if (node_dict.get("@", None) == "ColumnRef" and
+                len(node.fields) == 3 and
+                node.fields[0].sval == source
+            ):
+                node.fields[0].sval = target
 
             for node_type in node:
                 node_value = getattr(node, node_type)


### PR DESCRIPTION
When renaming the schema in queries, we missed the fact that the schema name can appear in ColumnRef.

This change add such a behaviour in. We are making an assumption that if a ColumnRef has 3 fields, the first one must be a schema name.